### PR TITLE
Explicitly install additional libraries

### DIFF
--- a/additional-libraries.txt
+++ b/additional-libraries.txt
@@ -1,2 +1,0 @@
-scipy
-numpy

--- a/additional-libraries.txt
+++ b/additional-libraries.txt
@@ -1,0 +1,2 @@
+scipy
+numpy

--- a/build-image.sh
+++ b/build-image.sh
@@ -26,7 +26,6 @@ mount --bind $PWD/components $TARGET/building
 echo "Copying in some drive scripts"
 cp /usr/bin/qemu-arm-static $TARGET/usr/bin/qemu-arm-static
 cp pi-main.sh $TARGET/main.sh
-cp additional-libraries.txt $TARGET/additional-libraries.txt
 
 # Disable ld preload
 mv $TARGET/etc/ld.so.preload ./ld.so.preload

--- a/build-image.sh
+++ b/build-image.sh
@@ -26,6 +26,8 @@ mount --bind $PWD/components $TARGET/building
 echo "Copying in some drive scripts"
 cp /usr/bin/qemu-arm-static $TARGET/usr/bin/qemu-arm-static
 cp pi-main.sh $TARGET/main.sh
+cp additional-libraries.txt $TARGET/additional-libraries.txt
+
 # Disable ld preload
 mv $TARGET/etc/ld.so.preload ./ld.so.preload
 

--- a/pi-main.sh
+++ b/pi-main.sh
@@ -73,5 +73,7 @@ proc	/proc	proc	defaults	0	0
 EOF
 
 echo "Installing additional libraries"
-pip install -r /additional-libraries.txt
+apt-get install -y \
+    python3-scipy \
+    python3-numpy
 

--- a/pi-main.sh
+++ b/pi-main.sh
@@ -74,3 +74,4 @@ EOF
 
 echo "Installing additional libraries"
 pip install -r /additional-libraries.txt
+

--- a/pi-main.sh
+++ b/pi-main.sh
@@ -71,3 +71,6 @@ proc	/proc	proc	defaults	0	0
 /dev/mmcblk0p1	/boot	vfat	defaults	0	2
 /dev/mmcblk0p2	/	ext4	defaults,noatime	0	1
 EOF
+
+echo "Installing additional libraries"
+pip install -r /additional-libraries.txt


### PR DESCRIPTION
Sometimes, using additional libraries in robot code helps a lot, especially in cementing real-world use cases for Python. Now we can explicitly install libraries into the environment to be used, outside of the ones our applications depend on.

Docs page created in https://github.com/sourcebots/docs/pull/42

(This PR doesn't add any additional ones, just adds `scipy` and `numpy` explicitly)