### PR TITLE
Put the sourcebots repo specification in its own file

### DIFF
--- a/pi-main.sh
+++ b/pi-main.sh
@@ -16,8 +16,8 @@ systemctl disable dhcpcd.service
 mkdir sb-debs
 
 echo "Adding local repository to sources"
-echo "deb [trusted=yes] file:/sb-debs ./" >> /etc/apt/sources.list
-echo "deb-src [trusted=yes] file:/sb-debs ./" >> /etc/apt/sources.list
+echo "deb [trusted=yes] file:/sb-debs ./" >> /etc/apt/sources.list.d/sourcebots.list
+echo "deb-src [trusted=yes] file:/sb-debs ./" >> /etc/apt/sources.list.d/sourcebots.list
 
 function rebuild_repo {
     pushd /sb-debs


### PR DESCRIPTION
This is both cleaner and will let us specify that we want to only update from that one repo when doing updates.