### PR TITLE
Also archive the built debs and an update package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,3 +31,8 @@ jobs:
             - store_artifacts:
                 path: pi-image.img.xz
                 destination: pi-image.img.xz
+            - store_artifacts:
+                path: sb-debs
+            - store_artifacts:
+                path: update.tar.xz
+                destination: update.tar.xz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
                 destination: pi-image.img.xz
             - store_artifacts:
                 path: sb-debs
+                destination: sb-debs
             - store_artifacts:
                 path: update.tar.xz
                 destination: update.tar.xz

--- a/build-image.sh
+++ b/build-image.sh
@@ -81,4 +81,4 @@ cp $IMAGE pi-image.img
 echo "Creating update package"
 # TODO: once `runusb` is up to date, use its `create-update` script instead of
 # duplicating that logic here (https://github.com/sourcebots/pi-image/issues/14)
-tar --create --xz --file update.tar.xz sb-debs/*.deb
+tar --create --xz --file update.tar.xz --transform 's_sb-debs/__g' -- sb-debs/*.deb

--- a/build-image.sh
+++ b/build-image.sh
@@ -79,4 +79,6 @@ sha1sum $IMAGE
 cp $IMAGE pi-image.img
 
 echo "Creating update package"
+# TODO: once `runusb` is up to date, use its `create-update` script instead of
+# duplicating that logic here (https://github.com/sourcebots/pi-image/issues/14)
 tar --create --xz --file update.tar.xz sb-debs/*.deb

--- a/build-image.sh
+++ b/build-image.sh
@@ -41,6 +41,9 @@ mv $TARGET/etc/ld.so.preload ./ld.so.preload
 
 chroot $TARGET /main.sh
 
+echo "Copying out the built packages"
+cp -r $TARGET/sb-debs .
+
 echo "Cleaning up: Removing drive scripts"
 
 rm $TARGET/main.sh
@@ -74,3 +77,6 @@ kpartx -d $IMAGE
 sha1sum $IMAGE
 
 cp $IMAGE pi-image.img
+
+echo "Creating update package"
+tar --create --xz --file update.tar.xz sb-debs/*.deb


### PR DESCRIPTION
This makes it easier to deploy updates as we can just grab the latest from this build and we can also easily link to them.