### PR TITLE
Quieten apt-get a little to remove the dynamic progress output

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -2,10 +2,10 @@
 
 set -e
 echo "Updating apt"
-apt-get update
+apt-get --quiet update
 
 function canhas {
-    DEBIAN_FRONTEND=noninteractive apt-get -y install $1
+    DEBIAN_FRONTEND=noninteractive apt-get --quiet -y install $1
 }
 
 echo "Installing dependencies"

--- a/pi-main.sh
+++ b/pi-main.sh
@@ -48,10 +48,10 @@ function buildme {
     rebuild_repo
 
     echo "Re-updating apt"
-    apt-get update -y
+    apt-get --quiet update -y
 
     echo "Installing $1"
-    apt-get -o "Dpkg::Options::=--force-confnew" install -y $1 || true
+    apt-get --quiet -o "Dpkg::Options::=--force-confnew" install -y $1 || true
 }
 
 buildme usbmount
@@ -72,7 +72,7 @@ proc	/proc	proc	defaults	0	0
 EOF
 
 echo "Installing additional libraries"
-apt-get install -y \
+apt-get --quiet install -y \
     python3-scipy \
     python3-numpy
 

--- a/pi-prebuild.sh
+++ b/pi-prebuild.sh
@@ -12,20 +12,20 @@ echo "Adding backports"
 echo "deb [trusted=yes] http://ftp.debian.org/debian stretch-backports main" >> /etc/apt/sources.list
 
 echo "Updating apt"
-apt-get update -y
+apt-get --quiet update -y
 
 echo "Upgrading anything out of date"
-apt-get upgrade -y
-apt-get dist-upgrade -y
+apt-get --quiet upgrade -y
+apt-get --quiet dist-upgrade -y
 
 echo "Installing git"
-apt-get install -y git
+apt-get --quiet install -y git
 
 echo "Installing build tools"
-apt-get install -y build-essential devscripts debhelper dh-systemd
+apt-get --quiet install -y build-essential devscripts debhelper dh-systemd
 
 echo "Installing some useful cached bits for downstream builds"
-apt-get install -y \
+apt-get --quiet install -y \
     libopencv-core-dev \
     libopencv-contrib-dev \
     libopencv-video-dev \
@@ -33,7 +33,7 @@ apt-get install -y \
     python3-dev
 
 echo "Install some useful tools for debugging"
-apt-get install -y \
+apt-get --quiet install -y \
     ipython3 \
     htop \
     python3-pip \
@@ -41,7 +41,7 @@ apt-get install -y \
     vim
 
 echo "Installing bits and pieces from backports"
-apt-get -t stretch install -y python3-cffi
+apt-get --quiet -t stretch install -y python3-cffi
 
 echo "Rebuilding locale"
 echo "en_GB.UTF-8 UTF-8" > /etc/locale.gen


### PR DESCRIPTION
I was hoping for an explicit config option for this, however there doesn't seem to be one. The man page for apt-get notes that the first level of --quiet (there are several) just turns off the progress output to make apt-get more suitable for logging.

This is mainly intended to make the output on CircleCI somewhat easier to read. Ideally we'd have a way to switch this off when running the build locally (where it's nice to have the pretty output), though that is a rarer scenario so I'm not particularly concerned.