### PR TITLE
Enable serial port

### DIFF
--- a/edit-boot.sh
+++ b/edit-boot.sh
@@ -10,6 +10,9 @@ mount /dev/mapper/loop0p1 $TARGET_BOOT
 
 echo 'dwc_otg.lpm_enable=0 console=serial0,115200 console=tty1 root=/dev/mmcblk0p2 rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait init=/sbin/init' > $TARGET_BOOT/cmdline.txt
 
+# Enable serial port for debugging.
+echo 'enable_uart=1' >> $TARGET_BOOT/config.txt
+
 echo "Unmounting boot"
 umount $TARGET_BOOT
 sync


### PR DESCRIPTION
With this option enabled, a serial cable can be connected to the
GPIO header in order to access a Linux console. This avoids the
need to configure the Pi's networking and set up an SSH server
(although it does require you to have a serial cable to hand).

The solution is taken from [this thread](https://www.raspberrypi.org/forums/viewtopic.php?f=28&t=141195).

Fixes #5.