### PR TITLE
Make the image download branch-agnostic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,10 @@ jobs:
             - run: git submodule update --init
             - run: sudo ./install-dependencies.sh
             - restore_cache:
-                key: baseimage-{{ .Branch }}-{{ checksum "download-image.sh" }}
+                key: baseimage-branch-agnostic-download-{{ checksum "download-image.sh" }}
             - run: ./download-image.sh /tmp/raspbian.zip
             - save_cache:
-                key: baseimage-{{ .Branch }}-{{ checksum "download-image.sh" }}
+                key: baseimage-branch-agnostic-download-{{ checksum "download-image.sh" }}
                 paths:
                   - /tmp/raspbian.zip
             - run: cp /tmp/raspbian.zip ./

--- a/download-image.sh
+++ b/download-image.sh
@@ -3,15 +3,18 @@
 # Serial: 2
 
 TARGET=${1:-raspbian.zip}
+# Note: if updating the image we're using, you should also update the hash
+# below. The hashes are available from Raspberry Pi as "$IMAGE.sha256".
 IMAGE=https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2017-12-01/2017-11-29-raspbian-stretch-lite.zip
 
-set -e
+echo "e942b70072f2e83c446b9de6f202eb8f9692c06e7d92c343361340cc016e0c9f $TARGET" > sha256
 
-if [ -f $TARGET ]; then
-    echo "Image already downloaded."
-    exit 0
-fi
+# If we already have the file, and it's got the right hash, then skip the download
+sha256sum --check sha256 && echo "Image already downloaded." && exit 0
+
+set -e
 
 echo "Downloading Raspbian image"
 curl -L $IMAGE -o $TARGET
 
+sha256sum --check sha256


### PR DESCRIPTION
This will chop 6 minutes off the PR builds by better leveraging caching on Circle CI. This also adds hashsum checking of the downloaded image, meaning that we're somewhat protected against accidental changes either on our end or on Raspberry Pi's end.