### PR TITLE
Enable wider use of the prebuild cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,11 +20,17 @@ jobs:
             - run: cp /tmp/raspbian.zip ./
             - restore_cache:
                 keys:
-                 - prebuilt-{{ checksum "download-image.sh" }}-{{ checksum "prebuild-image.sh" }}-{{ checksum "pi-prebuild.sh" }}-{{ .Branch }}
+                  # Branch specific cache with fallback to a general cache.
+                  # Note: the semi-random string at the end reduces the chances
+                  # that two branches where one is the prefix of another
+                  # (e.g: 'foo' and 'foo-bar') can accidentally share a cache.
+                  # While this is explicitly enabled by the second key, we don't
+                  # really want it happening under the first key.
+                 - prebuilt-{{ checksum "download-image.sh" }}-{{ checksum "prebuild-image.sh" }}-{{ checksum "pi-prebuild.sh" }}-{{ .Branch }}-Z@Z0
                  - prebuilt-{{ checksum "download-image.sh" }}-{{ checksum "prebuild-image.sh" }}-{{ checksum "pi-prebuild.sh" }}-
             - run: sudo ./prebuild-image.sh
             - save_cache:
-                key: prebuilt-{{ checksum "download-image.sh" }}-{{ checksum "prebuild-image.sh" }}-{{ checksum "pi-prebuild.sh" }}-{{ .Branch }}
+                key: prebuilt-{{ checksum "download-image.sh" }}-{{ checksum "prebuild-image.sh" }}-{{ checksum "pi-prebuild.sh" }}-{{ .Branch }}-Z@Z0
                 paths:
                   - /tmp/raspbian-base.img
             - run: sudo ./build-image.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,12 @@ jobs:
                   - /tmp/raspbian.zip
             - run: cp /tmp/raspbian.zip ./
             - restore_cache:
-                key: prebuilt-{{ .Branch }}-{{ checksum "download-image.sh" }}-{{ checksum "prebuild-image.sh" }}-{{ checksum "pi-prebuild.sh" }}
+                keys:
+                 - prebuilt-{{ checksum "download-image.sh" }}-{{ checksum "prebuild-image.sh" }}-{{ checksum "pi-prebuild.sh" }}-{{ .Branch }}
+                 - prebuilt-{{ checksum "download-image.sh" }}-{{ checksum "prebuild-image.sh" }}-{{ checksum "pi-prebuild.sh" }}-
             - run: sudo ./prebuild-image.sh
             - save_cache:
-                key: prebuilt-{{ .Branch }}-{{ checksum "download-image.sh" }}-{{ checksum "prebuild-image.sh" }}-{{ checksum "pi-prebuild.sh" }}
+                key: prebuilt-{{ checksum "download-image.sh" }}-{{ checksum "prebuild-image.sh" }}-{{ checksum "pi-prebuild.sh" }}-{{ .Branch }}
                 paths:
                   - /tmp/raspbian-base.img
             - run: sudo ./build-image.sh


### PR DESCRIPTION
This ensures that a branch's cache is still unique to that branch (meaning that if we mess up the prebuild it's still hard to leak that between branches), but by falling back to a checksum matching prebuild from another branch we're much more likely to find a matching cache and thus speed up the build.