### PR TITLE
make journald persist between reboots for easier debugging

### DIFF
--- a/pi-main.sh
+++ b/pi-main.sh
@@ -76,3 +76,5 @@ apt-get --quiet install -y \
     python3-scipy \
     python3-numpy
 
+# turn on persistent journalctl logging
+echo "Storage=persistent" >> /etc/systemd/journald.conf


### PR DESCRIPTION
currently we lose `journald` logs when we reboot, it would make it easier to debug students Pi's if we don't lose them.